### PR TITLE
accept all files. Closes: #5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,4 +11,4 @@ RUN sed -i -e "s/Components: main/& non-free/" /etc/apt/sources.list.d/debian.so
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-CMD ["bash", "-c", "mkdir -p /work/mibs && cp /usr/share/snmp/mibs/*MIB* /work/mibs && cp -r /var/lib/mibs/* /work/mibs"]
+CMD ["bash", "-c", "mkdir -p /work/mibs && cp /usr/share/snmp/mibs/*.txt /work/mibs && cp -r /var/lib/mibs/* /work/mibs"]

--- a/miburi/dump.go
+++ b/miburi/dump.go
@@ -5,7 +5,6 @@ import (
 	"encoding/gob"
 	"fmt"
 	"os"
-	"strings"
 
 	"github.com/sleepinggenius2/gosmi"
 )
@@ -113,7 +112,7 @@ func getMIBNames(paths []string) ([]string, error) {
 			return nil, err
 		}
 		for _, file := range files {
-			if !file.IsDir() && strings.Contains(file.Name(), "MIB") {
+			if !file.IsDir() {
 				mibs = append(mibs, file.Name())
 			}
 		}


### PR DESCRIPTION
全ファイルを取り込んだほうが安全だった (これにより1フォルダに全部つっこんだとしてもOIDをちゃんと引けるようになっている)